### PR TITLE
Python 3.6 Compatibility

### DIFF
--- a/test.py
+++ b/test.py
@@ -12,4 +12,4 @@ tt = TextTeaser()
 sentences = tt.summarize(title, text)
 
 for sentence in sentences:
-  print sentence
+  print(sentence)

--- a/textteaser/__init__.py
+++ b/textteaser/__init__.py
@@ -1,7 +1,6 @@
 # !/usr/bin/python
 # -*- coding: utf-8 -*-
-
-from summarizer import Summarizer
+from .summarizer import Summarizer
 
 
 class TextTeaser(object):

--- a/textteaser/main.py
+++ b/textteaser/main.py
@@ -1,4 +1,4 @@
-from summarizer import Summarizer
+from .summarizer import Summarizer
 
 
 def getInput():
@@ -28,6 +28,6 @@ result = summarizer.sortSentences(result[:30])
 print 'Summary:'
 
 for r in result:
-    print r['sentence']
-    # print r['totalScore']
-    # print r['order']
+    print(r['sentence'])
+    # print(r['totalScore'])
+    # print(r['order'])

--- a/textteaser/main.py
+++ b/textteaser/main.py
@@ -25,7 +25,7 @@ result = summarizer.summarize(input['text'], input['title'], 'Undefined', 'Undef
 result = summarizer.sortScore(result)
 result = summarizer.sortSentences(result[:30])
 
-print 'Summary:'
+print('Summary:')
 
 for r in result:
     print(r['sentence'])

--- a/textteaser/parser.py
+++ b/textteaser/parser.py
@@ -1,11 +1,16 @@
 # !/usr/bin/python
 # -*- coding: utf-8 -*-
 import nltk.data
-import os
+import os.path as path
 
 
 class Parser:
     def __init__(self):
+        self.basePath = '/'.join([
+            path.dirname(path.abspath(__file__)),
+            'trainer',
+            ''
+        ])
         self.ideal = 20.0
         self.stopWords = self.getStopWords()
 
@@ -58,7 +63,8 @@ class Parser:
         return len(matchedWords) / (len(title) * 1.0)
 
     def splitSentences(self, text):
-        tokenizer = nltk.data.load('file:' + os.path.dirname(os.path.abspath(__file__)).decode('utf-8') + '/trainer/english.pickle')
+        path = self.basePath + 'english.pickle'
+        tokenizer = nltk.data.load('file:' + path)
 
         return tokenizer.tokenize(text)
 
@@ -72,7 +78,8 @@ class Parser:
         return [word for word in words if word not in self.stopWords]
 
     def getStopWords(self):
-        with open(os.path.dirname(os.path.abspath(__file__)) + '/trainer/stopWords.txt') as file:
+        path = self.basePath + 'stopWords.txt'
+        with open(path) as file:
             words = file.readlines()
 
         return [word.replace('\n', '') for word in words]

--- a/textteaser/summarizer.py
+++ b/textteaser/summarizer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-from parser import Parser
+from .parser import Parser
 
 
 class Summarizer:


### PR DESCRIPTION
Changed across project:
* Convert ```print var``` calls to ```print(var)``` (compat)
* Change ```import``` statements (compat)
* Fix inconsistent line breaks (format)

Changed in ```parser.py```
* Import ```os.path``` more granularly
* Replace redundant path building

Retained:
* Python 2.7 compatibility (compat)
* non-PEP8 use of camelCase (format)