### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The original Scala TextTeaser can still be accessed [here](https://github.com/Mo
 ### Installation
 
     >>> git clone https://github.com/IndigoResearch/textteaser.git
-    >>> pip install -r textteaser/requirements.txt
+    >>> pip install -r textteaser/textteaser/requirements.txt
 
 ### How to Use
 


### PR DESCRIPTION
When checking out with git, the whole project is downloaded in a directory called "textteaser".
The command to be executed, then, is missing a "textteaser/" at the beginning.